### PR TITLE
Make params reactive

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,7 @@
 import {
   computed, ref, shallowRef, watch,
 } from 'vue';
+import { keysOf } from '@/utils';
 
 import type { Ref } from 'vue';
 import type { ComposableCreationOptions } from './types/composableCreation';
@@ -68,7 +69,7 @@ export const createPaginatedResourceComposable = (
       loading.value = false;
     };
 
-    watch(() => requestOptions, () => {
+    watch(keysOf(requestOptions).map((key) => () => requestOptions[key]), () => {
       elements.value = [];
       backendPage.value = 0;
       resetPage();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export const keysOf = <ObjectType>(object: ObjectType) => (
+  Object.keys(object) as Array<keyof ObjectType>
+);


### PR DESCRIPTION
## Description

Parameters are now reactive, meaning that changes to the params object will correctly reset the pagination to the first page and re-execute every request.

## Requirements

None.

## Additional changes

None.
