### PR TITLE
Enhance type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ interface Params {
   page?: number,
   size?: number,
   search: string,
+
+  // page-related params, don't get passed into the composable params
+  page: number,
+  size: number,
 }
 
 const getElements = async (

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,21 +5,27 @@ import { keysOf } from '@/utils';
 
 import type { Ref } from 'vue';
 import type { ComposableCreationOptions } from './types/composableCreation';
-import type { PaginatedRequestMethod } from './types/requests';
+import type { PageRelatedRequestOptions, PaginatedRequestMethod } from './types/requests';
 
-export const createPaginatedResourceComposable = (
-  composableOptions: ComposableCreationOptions,
-) => {
+export const createPaginatedResourceComposable = <
+  PageKeyType extends string = 'page',
+  PageSizeKeyType extends string | undefined = undefined,
+>(
+    composableOptions: ComposableCreationOptions<PageKeyType, PageSizeKeyType>,
+  ) => {
   const FRONTEND_PAGE_SIZE = composableOptions.frontend.pageSize;
   const BACKEND_PAGE_SIZE = composableOptions.backend?.pageSize;
   const BACKEND_PAGE_REQUEST_KEY = composableOptions.backend?.requestKeys?.page || 'page';
-  const BACKEND_PAGE_SIZE_REQUEST_KEY = composableOptions.backend?.requestKeys?.pageSize || 'size';
+  const BACKEND_PAGE_SIZE_REQUEST_KEY = composableOptions.backend?.requestKeys?.pageSize;
 
-  return <ElementType, OptionsType>(
+  return <ElementType, OptionsType extends PageRelatedRequestOptions<PageKeyType, PageSizeKeyType>>(
     paginatedRequestMethod: PaginatedRequestMethod<ElementType, OptionsType>,
     page: Ref<number>,
     resetPage: () => void,
-    requestOptions: OptionsType,
+    requestOptions: Omit<
+      OptionsType,
+      PageKeyType | (PageSizeKeyType extends string ? NonNullable<PageSizeKeyType> : never)
+    >,
   ) => {
     const elements = shallowRef<Array<ElementType>>([]);
     const loading = ref(false);
@@ -51,9 +57,22 @@ export const createPaginatedResourceComposable = (
     const requestNextPage = async () => {
       loading.value = true;
       backendPage.value += 1;
-      const internalRequestOptions = {
-        [BACKEND_PAGE_REQUEST_KEY]: backendPage.value,
-        [BACKEND_PAGE_SIZE_REQUEST_KEY]: BACKEND_PAGE_SIZE,
+
+      // @ts-expect-error: The union of the page-related keys isn't perfect
+      const pageRelatedRequestOptions: PageRelatedRequestOptions<PageKeyType, PageSizeKeyType> = {
+        [BACKEND_PAGE_REQUEST_KEY as PageKeyType]: backendPage.value,
+        ...(
+          BACKEND_PAGE_SIZE_REQUEST_KEY !== undefined && {
+            [
+              BACKEND_PAGE_SIZE_REQUEST_KEY as NonNullable<PageSizeKeyType>
+            ]: BACKEND_PAGE_SIZE as number,
+          }
+        ),
+      };
+
+      // @ts-expect-error: The union of the `requestOptions` and the page-related keys isn't perfect
+      const internalRequestOptions: OptionsType = {
+        ...pageRelatedRequestOptions,
         ...requestOptions,
       };
       const {

--- a/src/types/composableCreation.ts
+++ b/src/types/composableCreation.ts
@@ -1,14 +1,17 @@
-export interface ComposableCreationOptions {
+export interface ComposableCreationOptions<
+  PageKeyType extends string,
+  PageSizeKeyType extends string | undefined,
+  PageSizeType = PageSizeKeyType extends string ? number : never,
+> {
   frontend: {
     pageSize: number,
   },
   backend?: {
-    pageSize?: number,
+    pageSize?: PageSizeType,
     requestKeys?: {
       /** @defaultValue 'page' */
-      page?: string,
-      /** @defaultValue 'size' */
-      pageSize?: string,
+      page: PageKeyType,
+      pageSize?: PageSizeKeyType,
     },
   },
 }

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -5,3 +5,14 @@ export type PaginatedRequestMethod<
   total: number,
   elements: Array<ElementType>,
 }>;
+
+export type PageRelatedRequestOptions<
+  PageKeyType extends string,
+  PageSizeKeyType extends string | undefined,
+> = (
+  Record<PageKeyType, number> & (
+    PageSizeKeyType extends string
+      ? Record<NonNullable<PageSizeKeyType>, number>
+      : Record<never, never>
+  )
+)


### PR DESCRIPTION
## Description

Now the `page` and `pageSize` parameters are required in the `paginatedRequestMethod` parameters, and are stripped in the `requestOptions` parameter, so the user can expect to use them inside the `paginatedRequestMethod` but doesn't have to handle them from outside (this was already the way thinks worked, but the typing wasn't helping)

## Requirements

None.

## Additional changes

None.
