### PR TITLE
Fix `ComposableCreationOptions` interface error

### DIFF
--- a/src/types/composableCreation.ts
+++ b/src/types/composableCreation.ts
@@ -7,11 +7,11 @@ export interface ComposableCreationOptions<
     pageSize: number,
   },
   backend?: {
-    pageSize?: PageSizeType,
     requestKeys?: {
       /** @defaultValue 'page' */
-      page: PageKeyType,
+      page?: PageKeyType,
       pageSize?: PageSizeKeyType,
     },
+    pageSize?: PageSizeType,
   },
 }


### PR DESCRIPTION
## Description

Make the `backend.requestKeys.page` option to be optional on the `ComposableCreationOptions` interface.

## Requirements

None.

## Additional changes

None.
