### PR TITLE
Fix documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export interface Resource {
   imageUrl: string,
 }
 
-type AdapterResponse = Promise<{ total: number, elements: Array<Resource> }>;
+type Response = Promise<{ total: number, elements: Array<Resource> }>;
 
 interface Options {
   'page-number': number,
@@ -117,7 +117,7 @@ interface Options {
   search: string,
 }
 
-export const getResource = (options: Options): AdapterResponse => {
+export const getResource = async (options: Options): Response => {
   const response = await axios.get(
     'https://some.url/resource',
     { params: options },

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@
   </a>
 </p>
 
-**Vue Paginated Resource** is a tool that helps you consume a paginated resource endpoint and display its contents on a paginated fashion in your frontend, leaving the coordination heavy lifting out of your way.
+**Vue Paginated Resource** is a tool that helps you consume a paginated resource endpoint and display its contents in a paginated fashion in your frontend, leaving the coordination heavy lifting between the backend and the frontend out of your way.
 
 ## Why Vue Paginated Resource?
 
 Let's face it: integrating backend-paginated resources into a paginated frontend **sucks**. Handling page requests, loading states and edge cases for **every resource** may very well be one of hell's worst tortures.
 
-And there is no way around it: when you have to paginate, you have to paginate. That's where **Vue Paginated Resource** comes in. With this tool, you can forget about the backend pagination and think in terms of the pages being viewed by the frontend user.
+And there is no way around it: when you have to paginate, you have to paginate. That's where **Vue Paginated Resource** comes in. With this tool, you can forget about the backend pagination and just handle the page being displayed on the screen. We will handle the rest.
 
 ## Installation
 


### PR DESCRIPTION
## Description

The documentation had a bad example (an async function not being declared async). This got fixed.

## Requirements

None.

## Additional changes

None.
